### PR TITLE
refactor: Replace CheckExistence function by GetWIthCPF function on account contract

### DIFF
--- a/app/core/model/account/repo.go
+++ b/app/core/model/account/repo.go
@@ -26,9 +26,6 @@ type Repository interface {
 	// Create creates a new account and returns its new id
 	Create(ctx context.Context, account *Account) (id.ExternalID, error)
 
-	// CheckExistence checks if a document is registered to any account and throws an error if it is
-	CheckExistence(ctx context.Context, document document.Document) error
-
 	// UpdateBalance replaces the balance of the account with the id provided
 	UpdateBalance(ctx context.Context, id id.ExternalID, balance currency.Currency) error
 

--- a/app/gateway/database/postgres/account.go
+++ b/app/gateway/database/postgres/account.go
@@ -121,19 +121,6 @@ func (t *accountRepo) Create(ctx context.Context, acc *account.Account) (id.Exte
 	return acc.ExternalID, nil
 }
 
-func (t *accountRepo) CheckExistence(ctx context.Context, document document.Document) error {
-	const query string = "select count(*) as quantity from accounts where document = $1"
-	ret := t.db.QueryRow(ctx, query, document)
-	var quantity int
-	if err := ret.Scan(&quantity); err != nil {
-		return err
-	}
-	if quantity > 0 {
-		return account.ErrAlreadyExist
-	}
-	return nil
-}
-
 func (t *accountRepo) UpdateBalance(ctx context.Context, id id.ExternalID, balance currency.Currency) error {
 	db, found := t.tx.From(ctx)
 	if !found {

--- a/app/workspaces/accounts/create.go
+++ b/app/workspaces/accounts/create.go
@@ -34,9 +34,12 @@ func (u *workspace) Create(ctx context.Context, req CreateInput) (CreateOutput, 
 	}
 
 	//Checks document uniqueness
-	err := u.ac.CheckExistence(ctx, req.Document)
-	if err != nil {
+	res, err := u.ac.GetWithCPF(ctx, req.Document)
+	if err != nil && err != account.ErrNotFound {
 		return response, err
+	}
+	if res.Document != "" {
+		return response, account.ErrAlreadyExist
 	}
 
 	acc := account.Account{


### PR DESCRIPTION
This pull request intends to replace the CheckExistence function, which checks if an register with the CPF passed as a parameter exists in the database, returning an error if it doesn't, by the GetWIthCPF, which returns an account with the CPF provided or fails in case it can not be found.

The reason for the replacement is that the GetWithCPF function can be used in more places, and the CheckExistence can't. This way, the contract had two functions with similar purposes.

closes #13