### PR TITLE
feat: validate document with regexp

### DIFF
--- a/app/core/types/document/document.go
+++ b/app/core/types/document/document.go
@@ -1,37 +1,30 @@
 package document
 
 import (
-	"errors"
-	"strconv"
-	"strings"
+	"regexp"
 )
 
-// Document is an implementation of a string that has other functions to allow validation
+var (
+	exp = regexp.MustCompile("([^0-9])+")
+)
+
+// Document is an implementation of a CPF
+// string that has functions to validate CPFs
 type Document string
 
 // Validate validates a document
-func (d *Document) Validate() error {
-	for _, digit := range *d {
-		_, err := strconv.Atoi(string(digit))
-		if err != nil {
-			return errors.New("")
-		}
+func (d Document) Validate() error {
+	if len(d) != 11 {
+		return ErrInvalidDocument
 	}
-	if len(*d) != 11 {
-		return errors.New("")
+
+	if exp.Match([]byte(d)) {
+		return ErrInvalidDocument
 	}
 	return nil
 }
 
 // Normalize removes all special characters from a document string
 func Normalize(document string) string {
-	return strings.Trim(
-		strings.ReplaceAll(
-			strings.ReplaceAll(
-				strings.ReplaceAll(
-					strings.ReplaceAll(document, ".", ""),
-					"-", ""),
-				"/", ""),
-			",", ""),
-		" ")
+	return exp.ReplaceAllString(document, "")
 }

--- a/app/core/types/document/errors.go
+++ b/app/core/types/document/errors.go
@@ -1,0 +1,9 @@
+package document
+
+import "errors"
+
+var (
+
+	// ErrInvalidDocument occurs when a CPF provided by the client is invalid or contains special characters
+	ErrInvalidDocument = errors.New("the document provided is invalid. please inform a valid cpf")
+)


### PR DESCRIPTION
This pull request intends to implement regular expressions into the document validation module. This way, CPFs validations and replacements can be more assertive.

closes #9 