### PR TITLE
style: expose field names in sql queries

### DIFF
--- a/app/gateway/database/postgres/account/get.go
+++ b/app/gateway/database/postgres/account/get.go
@@ -7,7 +7,19 @@ import (
 )
 
 func (r *repository) Get(ctx context.Context, id id.ExternalID) (account.Account, error) {
-	const query string = "select * from accounts where external_id = $1"
+	const query string = `select 
+		id, 
+		external_id, 
+		name, 
+		document, 
+		balance, 
+		secret, 
+		updated_at, 
+		created_at 
+	from 
+		accounts
+	where external_id = $1`
+
 	acc := account.Account{}
 	ret := r.db.QueryRow(ctx, query, id)
 	acc, err := parse(ret, acc)

--- a/app/gateway/database/postgres/account/get_with_cpf.go
+++ b/app/gateway/database/postgres/account/get_with_cpf.go
@@ -7,7 +7,20 @@ import (
 )
 
 func (r *repository) GetWithCPF(ctx context.Context, document document.Document) (account.Account, error) {
-	const query string = "select * from accounts where document = $1"
+	const query string = `select 
+		id, 
+		external_id, 
+		name, 
+		document, 
+		balance, 
+		secret, 
+		updated_at, 
+		created_at 
+	from 
+		accounts 
+	where 
+		document = $1`
+
 	ret := r.db.QueryRow(ctx, query, document)
 	acc := account.Account{}
 	acc, err := parse(ret, acc)

--- a/app/gateway/database/postgres/account/list.go
+++ b/app/gateway/database/postgres/account/list.go
@@ -7,7 +7,17 @@ import (
 )
 
 func (r *repository) List(ctx context.Context, filter account.Filter) ([]account.Account, error) {
-	query := "select * from accounts"
+	query := `select 
+		id, 
+		external_id, 
+		name, 
+		document, 
+		balance, 
+		secret, 
+		updated_at, 
+		created_at 
+	from 
+		accounts`
 	args := make([]interface{}, 0)
 	if filter.Name != "" {
 		query = common.AppendCondition(query, "and", "name like ?")

--- a/app/gateway/database/postgres/account/repository.go
+++ b/app/gateway/database/postgres/account/repository.go
@@ -18,7 +18,7 @@ func NewRepository(db *pgxpool.Pool) account.Repository {
 }
 
 func parse(row common.Scanner, acc account.Account) (account.Account, error) {
-	err := row.Scan(&acc.ID, &acc.Name, &acc.Document, &acc.Balance, &acc.Secret, &acc.UpdatedAt, &acc.CreatedAt)
+	err := row.Scan(&acc.ID, &acc.ExternalID, &acc.Name, &acc.Document, &acc.Balance, &acc.Secret, &acc.UpdatedAt, &acc.CreatedAt)
 	if err != nil {
 		return acc, err
 	}

--- a/app/gateway/database/postgres/transfer/get.go
+++ b/app/gateway/database/postgres/transfer/get.go
@@ -7,7 +7,17 @@ import (
 )
 
 func (r *repository) Get(ctx context.Context, id id.ExternalID) (transfer.Transfer, error) {
-	const query string = "select * from transfers where id = $1"
+	const query string = `select
+		id
+		external_id
+		origin_id
+		destination_id
+		amount
+		effective_date
+		updated_at
+		created_at
+	from transfers where id = $1`
+
 	ret := r.db.QueryRow(ctx, query, id)
 	tr := transfer.Transfer{}
 	tr, err := parse(ret, tr)

--- a/app/gateway/database/postgres/transfer/repository.go
+++ b/app/gateway/database/postgres/transfer/repository.go
@@ -12,7 +12,7 @@ type repository struct {
 }
 
 func parse(row common.Scanner, tr transfer.Transfer) (transfer.Transfer, error) {
-	err := row.Scan(&tr.ID, &tr.OriginID, &tr.DestinationID, &tr.Amount, &tr.EffectiveDate, &tr.UpdatedAt, &tr.CreatedAt)
+	err := row.Scan(&tr.ID, &tr.ExternalID, &tr.OriginID, &tr.DestinationID, &tr.Amount, &tr.EffectiveDate, &tr.UpdatedAt, &tr.CreatedAt)
 	if err != nil {
 		return tr, err
 	}

--- a/app/workspaces/transfer/create.go
+++ b/app/workspaces/transfer/create.go
@@ -34,7 +34,7 @@ func (u *workspace) Create(ctx context.Context, req CreateInput) (CreateOutput, 
 	}
 
 	// Checks if the origin and destination accounts are the same
-	if t.DestinationID == t.OriginID {
+	if req.DestID == req.OriginID {
 		return response, transfer.ErrSameAccount
 	}
 


### PR DESCRIPTION
**PULL REQUEST SCOPE**

- Removed any SQL wildcard "*" for the specific fields expected in each case. This way, as pointed out by (just found out i can't mention y'all) Bella, the query gains performance and the expected fields are always received, even if the database schema changes. 

- Fixed some validations in the use case layer that was being done incorrectly and, thus, failing all tests made on that use case.

closes #5 