### PR TITLE
refac: made function to create pg url

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -39,7 +39,7 @@ func NewApplication(ctx context.Context, cfg config.Config) (*Application, error
 
 	accountsRepository := account.NewRepository(p)
 	transfersRepository := transfer.NewRepository(p)
-	transactionManager := transaction.NewTransaction(p)
+	transactionManager := transaction.NewManager(p)
 
 	accountsWorkspace := accountworkspace.New(accountsRepository, transactionManager, am)
 	transferWorkspace := transferworkspace.New(accountsRepository, transfersRepository, transactionManager, am)

--- a/app/app.go
+++ b/app/app.go
@@ -2,8 +2,6 @@ package app
 
 import (
 	"context"
-	"fmt"
-	"github.com/pkg/errors"
 	"stonehenge/app/config"
 	"stonehenge/app/core/entities/access"
 	accessimpl "stonehenge/app/gateway/access"
@@ -16,12 +14,14 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/jackc/pgx/v4/pgxpool"
 )
 
 type Application struct {
-	Accounts  accountworkspace.Workspace
-	Transfers transferworkspace.Workspace
+	Accounts      accountworkspace.Workspace
+	Transfers     transferworkspace.Workspace
 	AccessManager access.Manager
 }
 
@@ -56,13 +56,13 @@ func setupAccessManager(cfg config.AccessConfigurations) (access.Manager, error)
 		return accessimpl.Manager{}, errors.Wrap(err, "failed parsing access expiration time")
 	}
 
-	return accessimpl.NewManager(time.Minute * time.Duration(duration), []byte(cfg.SigningKey)), err
+	return accessimpl.NewManager(time.Minute*time.Duration(duration), []byte(cfg.SigningKey)), err
 }
 
 func setupDB(ctx context.Context, cfg config.DatabaseConfigurations) (*pgxpool.Pool, error) {
 
-	url := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s", cfg.User, cfg.Password, cfg.Host, cfg.Port, cfg.Name, cfg.SSLMode)
-	conn, err := postgres.NewConnection(ctx, url, "", nil, 5)
+	url := postgres.CreateDatabaseURL(cfg.User, cfg.Password, cfg.Host, cfg.Port, cfg.Name, cfg.SSLMode)
+	conn, err := postgres.NewConnection(ctx, url, nil, 5)
 	if err != nil {
 		return conn, err
 	}

--- a/app/core/entities/transaction/transaction.go
+++ b/app/core/entities/transaction/transaction.go
@@ -2,8 +2,8 @@ package transaction
 
 import "context"
 
-// Transaction is an object that encapsulates many storage accesses into one transaction
-type Transaction interface {
+// Manager is an object that encapsulates many storage accesses into one transaction
+type Manager interface {
 	// Begin starts a transaction and stores an object to it in this context
 	Begin(context.Context) (context.Context, error)
 

--- a/app/gateway/database/postgres/account/create_test.go
+++ b/app/gateway/database/postgres/account/create_test.go
@@ -15,7 +15,7 @@ func TestCreate(t *testing.T) {
 		t.Fatalf("could not get database: %v", err)
 	}
 
-	tx := transaction.NewTransaction(db)
+	tx := transaction.NewManager(db)
 
 	type args struct {
 		ctx     context.Context

--- a/app/gateway/database/postgres/postgres.go
+++ b/app/gateway/database/postgres/postgres.go
@@ -30,7 +30,7 @@ func Migrate(db string, filesPath string) error {
 		return errors.Wrap(err, "could not start migration")
 	}
 
-	if err := migration.Up(); err != nil && err != migrate.ErrNoChange {
+	if err := migration.Up(); err != nil && errors.Is(err, migrate.ErrNoChange) {
 		return errors.Wrap(err, "error uploading migration")
 	}
 

--- a/app/gateway/database/postgres/postgrestest/database.go
+++ b/app/gateway/database/postgres/postgrestest/database.go
@@ -2,18 +2,18 @@ package postgrestest
 
 import (
 	"context"
-	"fmt"
-	"github.com/jackc/pgx/v4/pgxpool"
 	"stonehenge/app/core/entities/account"
 	"stonehenge/app/core/entities/transfer"
 	"stonehenge/app/gateway/database/postgres"
+
+	"github.com/jackc/pgx/v4/pgxpool"
 )
 
 func connect(user, password, host, port, database, migrations string) (*pgxpool.Pool, error) {
 	ctx := context.Background()
-	url := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", user, password, host, port, database)
+	url := postgres.CreateDatabaseURL(user, password, host, port, database, "disable")
 
-	db, err := postgres.NewConnection(ctx, url, "", nil, 0)
+	db, err := postgres.NewConnection(ctx, url, nil, 0)
 	if err != nil {
 		return db, err
 	}

--- a/app/gateway/database/postgres/transaction/begin.go
+++ b/app/gateway/database/postgres/transaction/begin.go
@@ -5,7 +5,7 @@ import (
 	"stonehenge/app/gateway/database/postgres/common"
 )
 
-func (t *pgxTransaction) Begin(ctx context.Context) (context.Context, error) {
+func (t *manager) Begin(ctx context.Context) (context.Context, error) {
 	tx, err := t.db.Begin(ctx)
 	if err != nil {
 		return ctx, err

--- a/app/gateway/database/postgres/transaction/commit.go
+++ b/app/gateway/database/postgres/transaction/commit.go
@@ -5,7 +5,7 @@ import (
 	"stonehenge/app/gateway/database/postgres/common"
 )
 
-func (t *pgxTransaction) Commit(ctx context.Context) error {
+func (t *manager) Commit(ctx context.Context) error {
 	tx, err := common.TransactionFrom(ctx)
 	if err != nil {
 		return err

--- a/app/gateway/database/postgres/transaction/rollback.go
+++ b/app/gateway/database/postgres/transaction/rollback.go
@@ -5,7 +5,7 @@ import (
 	"stonehenge/app/gateway/database/postgres/common"
 )
 
-func (t *pgxTransaction) Rollback(ctx context.Context) {
+func (t *manager) Rollback(ctx context.Context) {
 	tx, err := common.TransactionFrom(ctx)
 	if err != nil {
 		return

--- a/app/gateway/database/postgres/transaction/transaction.go
+++ b/app/gateway/database/postgres/transaction/transaction.go
@@ -5,13 +5,13 @@ import (
 	"stonehenge/app/core/entities/transaction"
 )
 
-type pgxTransaction struct {
+type manager struct {
 	db *pgxpool.Pool
 }
 
-// NewTransaction creates a transaction adapter object
-func NewTransaction(db *pgxpool.Pool) transaction.Transaction {
-	return &pgxTransaction{
+// NewManager creates a transaction adapter object
+func NewManager(db *pgxpool.Pool) transaction.Manager {
+	return &manager{
 		db: db,
 	}
 }

--- a/app/gateway/database/postgres/transfer/create_test.go
+++ b/app/gateway/database/postgres/transfer/create_test.go
@@ -16,7 +16,7 @@ func TestCreate(t *testing.T) {
 		t.Fatalf("could not get database: %v", err)
 	}
 
-	tx := transaction.NewTransaction(db)
+	tx := transaction.NewManager(db)
 
 	type args struct {
 		ctx      context.Context

--- a/app/workspaces/account/authenticate_test.go
+++ b/app/workspaces/account/authenticate_test.go
@@ -33,7 +33,7 @@ func TestAuthentication(t *testing.T) {
 	}
 
 	type fields struct {
-		tx   transaction.Transaction
+		tx   transaction.Manager
 		tk   access.Manager
 		repo account.Repository
 	}

--- a/app/workspaces/account/create_test.go
+++ b/app/workspaces/account/create_test.go
@@ -33,7 +33,7 @@ func TestAccountCreation(t *testing.T) {
 	}
 
 	type fields struct {
-		tx   transaction.Transaction
+		tx   transaction.Manager
 		tk   access.Manager
 		repo account.Repository
 	}

--- a/app/workspaces/account/get_balance_test.go
+++ b/app/workspaces/account/get_balance_test.go
@@ -25,7 +25,7 @@ func TestGetBalance(t *testing.T) {
 	}
 
 	type fields struct {
-		tx   transaction.Transaction
+		tx   transaction.Manager
 		tk   access.Manager
 		repo account.Repository
 	}

--- a/app/workspaces/account/list_test.go
+++ b/app/workspaces/account/list_test.go
@@ -24,7 +24,7 @@ func TestList(t *testing.T) {
 	}
 
 	type fields struct {
-		tx   transaction.Transaction
+		tx   transaction.Manager
 		tk   access.Manager
 		repo account.Repository
 	}

--- a/app/workspaces/account/workspace.go
+++ b/app/workspaces/account/workspace.go
@@ -24,11 +24,11 @@ type Workspace interface {
 
 type workspace struct {
 	ac account.Repository
-	tx transaction.Transaction
+	tx transaction.Manager
 	tk access.Manager
 }
 
-func New(ac account.Repository, tx transaction.Transaction, tk access.Manager) *workspace {
+func New(ac account.Repository, tx transaction.Manager, tk access.Manager) *workspace {
 	return &workspace{
 		ac: ac,
 		tx: tx,

--- a/app/workspaces/transfer/create_test.go
+++ b/app/workspaces/transfer/create_test.go
@@ -41,7 +41,7 @@ func TestCreate(t *testing.T) {
 	}
 
 	type fields struct {
-		tx transaction.Transaction
+		tx transaction.Manager
 		tk access.Manager
 		ac account.Repository
 		tr transfer.Repository

--- a/app/workspaces/transfer/list_test.go
+++ b/app/workspaces/transfer/list_test.go
@@ -27,7 +27,7 @@ func TestList(t *testing.T) {
 	}
 
 	type fields struct {
-		tx transaction.Transaction
+		tx transaction.Manager
 		ac account.Repository
 		tr transfer.Repository
 		tk access.Manager

--- a/app/workspaces/transfer/workspace.go
+++ b/app/workspaces/transfer/workspace.go
@@ -18,11 +18,11 @@ type Workspace interface {
 type workspace struct {
 	ac account.Repository
 	tr transfer.Repository
-	tx transaction.Transaction
+	tx transaction.Manager
 	tk access.Manager
 }
 
-func New(ac account.Repository, tr transfer.Repository, tx transaction.Transaction, tk access.Manager) *workspace {
+func New(ac account.Repository, tr transfer.Repository, tx transaction.Manager, tk access.Manager) *workspace {
 	return &workspace{
 		ac: ac,
 		tr: tr,


### PR DESCRIPTION
This commit intends to create an easier way to create connections to the database by implementing a function that creates the URL once, instead of calling fmt.Sprintf() everywhere in the app