### PR TITLE
feat: make account filter case insensitive

### DIFF
--- a/app/gateway/postgres/account/list.go
+++ b/app/gateway/postgres/account/list.go
@@ -22,7 +22,7 @@ func (r *repository) List(ctx context.Context, filter account.Filter) ([]account
 		accounts`
 	args := make([]interface{}, 0)
 	if filter.Name != "" {
-		query = common.AppendCondition(query, "and", "name like ?", 1)
+		query = common.AppendCondition(query, "and", "name ilike ?", 1)
 		args = append(args, "%"+filter.Name+"%")
 	}
 


### PR DESCRIPTION
This pull request intends to allow API users to search for an account with their owner names, being it upper or lowercase.
closes #54 